### PR TITLE
chore(core): remove debug log from package entry

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,5 @@
 import './styles.css';
 
-console.log('BlossomColorPicker Entry Loaded');
-
 // Main class
 export { BlossomColorPicker } from './BlossomColorPicker';
 export type { BlossomColorPickerOptions } from './BlossomColorPicker';


### PR DESCRIPTION
## Summary
Removes the `console.log` call from `@blossom-color-picker/core` entry (`packages/core/src/index.ts`).

## Motivation
The message runs whenever the bundle loads, which adds noise to the consumer’s browser console (including production). Libraries typically avoid unconditional logging from the entry point.

## Changes
- Delete `console.log('BlossomColorPicker Entry Loaded')` from the main entry module.

No API or behavioral changes.